### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@
 #           make build
 
 #       - name: Publish to Registry
-#         uses: elgohr/Publish-Docker-Github-Action@master
+#         uses: elgohr/Publish-Docker-Github-Action@v5
 #         with:
 #           name: sailor1921/go-marketplace
 #           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore